### PR TITLE
Added GitHub-esque diff syntax highlighting

### DIFF
--- a/GitHub.tmTheme
+++ b/GitHub.tmTheme
@@ -395,6 +395,56 @@
               <string>#445588</string>
           </dict>
       </dict>
+
+    <!-- Diff -->
+    <dict>
+      <key>name</key>
+      <string>diff.header</string>
+      <key>scope</key>
+      <string>meta.diff, meta.diff.header</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#75715E</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>diff.deleted</string>
+      <key>scope</key>
+      <string>markup.deleted</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#770000</string>
+        <key>background</key>
+        <string>#FFDDDD</string>        
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>diff.inserted</string>
+      <key>scope</key>
+      <string>markup.inserted</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#003300</string>
+        <key>background</key>
+        <string>#DDFFDD</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>diff.changed</string>
+      <key>scope</key>
+      <string>markup.changed</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#ececec</string>
+      </dict>
+    </dict>
     </array>
     <key>uuid</key>
     <string>BF4E1964-0DB9-4E88-8142-E8F52D7EDEEC</string>


### PR DESCRIPTION
I thought it might be a good feature add to expand the syntax highlighting to `diff` views. I know that not many people are using Sublime Text for this purpose, but I've found good use for it when I use the [SublimeGit](https://github.com/SublimeGit/SublimeGit) plugin. 

**Example:**

![gst_diffsyn](https://cloud.githubusercontent.com/assets/5373700/2923336/dcffbb60-d713-11e3-9883-fdf2318835e0.png)

Thoughts?
